### PR TITLE
Add os time support and small fixes for vpk export

### DIFF
--- a/platform/vita/export/export.cpp
+++ b/platform/vita/export/export.cpp
@@ -324,7 +324,7 @@ public:
 			}
 		}
 
-		create_vpk(sfo->title + ".vpk", app_dir);
+		create_vpk(base_path + ".vpk", app_dir);
 		memdelete(sfo);
 		memdelete(da);
 		da = nullptr;

--- a/platform/vita/export/export.cpp
+++ b/platform/vita/export/export.cpp
@@ -243,7 +243,7 @@ public:
 		sfo->parental_level = p_preset->get("param_sfo/parental_level");
 
 		String icon = p_preset->get("assets/bubble_icon_128x128");
-		String splash = p_preset->get("assets/launch_splash_960x544");
+		String splash = p_preset->get("assets/app_splash_960x544");
 		String livearea_bg = p_preset->get("assets/livearea_bg_840x500");
 		String livearea_startup_button = p_preset->get("assets/livearea_startup_button_280x158");
 

--- a/platform/vita/os_vita.h
+++ b/platform/vita/os_vita.h
@@ -119,6 +119,7 @@ public:
 	virtual bool can_draw() const;
 
 	void key(uint32_t p_key, bool p_pressed);
+	virtual bool has_touchscreen_ui_hint() const;
 	virtual bool has_virtual_keyboard() const;
 	virtual void show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2(), bool p_multiline = false, int p_max_input_length = -1, int p_cursor_start = -1, int p_cursor_end = -1);
 	virtual void hide_virtual_keyboard();
@@ -155,6 +156,9 @@ public:
 	virtual Date get_date(bool local = false) const;
 	virtual Time get_time(bool local = false) const;
 	virtual TimeZoneInfo get_time_zone_info() const;
+	virtual uint64_t get_unix_time() const;
+	virtual uint64_t get_system_time_secs() const;
+	virtual uint64_t get_system_time_msecs() const;
 	virtual void delay_usec(uint32_t p_usec) const;
 	virtual uint64_t get_ticks_usec() const;
 	virtual String get_stdin_string();


### PR DESCRIPTION
When exporting the vita vpk files, I found that the export path and splash path settings did not take effect, and made corresponding repairs.